### PR TITLE
make_openbazaar.sh typo fix for bash and fish shells, remove brew call and added wine as required dep in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To build the Windows installer on Linux and OSX you can run:
 * sh make_openbazaar.sh win64 (64-bit)
 
 Remember to clear out the temp/ folder before building a different architecture
+You need of wine as build dependency. Install it on brew (OSX) or do a query on
+your Linux package manager.
 
 ## OSX
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ To build the Windows installer on Linux and OSX you can run:
 * sh make_openbazaar.sh win32 (32-bit)
 * sh make_openbazaar.sh win64 (64-bit)
 
-Remember to clear out the temp/ folder before building a different architecture
+Remember to clear out the temp/ folder before building a different architecture.
+
 You need of wine as build dependency. Install it on brew (OSX) or do a query on
 your Linux package manager.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 In this repository we'll have the scripts necessary to create binary distributions for different operating systems.
 The goal here is to have a 1-step build process.
 
+You need of the follow dependencies:
+wine
+grunt
+nodejs (npm executable) 
+(optional) upx and ucl to optimize standalone executable
+
+Install them on brew (OSX) or do a query on
+your Linux package manager.
+
 This repository is not to install the software, but to BUILD the installer itself. We will make downloadable installer executables available at https://openbazaar.org.
 
 This creation script has only been tested running on OS X Yosemite.
@@ -19,9 +28,6 @@ To build the Windows installer on Linux and OSX you can run:
 * sh make_openbazaar.sh win64 (64-bit)
 
 Remember to clear out the temp/ folder before building a different architecture.
-
-You need of wine as build dependency. Install it on brew (OSX) or do a query on
-your Linux package manager.
 
 ## OSX
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ your Linux package manager.
 
 This repository is not to install the software, but to BUILD the installer itself. We will make downloadable installer executables available at https://openbazaar.org.
 
-This creation script has only been tested running on OS X Yosemite.
+This creation script has been tested running on OS X Yosemite, Win32, Win64.
 
 ## Linux
 
@@ -30,8 +30,6 @@ To build the Windows installer on Linux and OSX you can run:
 
 * sh make_openbazaar.sh win32 (32-bit)
 * sh make_openbazaar.sh win64 (64-bit)
-
-Remember to clear out the temp/ folder before building a different architecture.
 
 ## OSX
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ In this repository we'll have the scripts necessary to create binary distributio
 The goal here is to have a 1-step build process.
 
 You need of the follow dependencies:
+
 wine
+
 grunt
+
 nodejs (npm executable) 
+
 (optional) upx and ucl to optimize standalone executable
 
 Install them on brew (OSX) or do a query on

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -93,9 +93,10 @@ case $OS in win32*)
             wget http://upx.sourceforge.net/download/upx391w.zip -O upx.zip
 	    unzip -j upx.zip
         fi
-        if [ ! -f electron.zip ]; then
-            wget https://github.com/atom/electron/releases/download/v0.36.0/electron-v0.36.0-win32-ia32.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
-        fi
+
+#        if [ ! -f electron.zip ]; then
+#            wget https://github.com/atom/electron/releases/download/v0.36.2/electron-v0.36.2-win32-ia32.zip -O electron.zip && unzip #electron.zip -d electron && rm electron.zip
+#        fi
 
         if [ ! -f python-2.7.11.msi ]; then
             wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi -O python-2.7.11.msi
@@ -116,7 +117,6 @@ case $OS in win32*)
     win64*)
         export OB_OS=win64
 
-       	npm install grunt-cli
         npm install electron-packager
 
         echo 'Compiling node packages'
@@ -127,7 +127,7 @@ case $OS in win32*)
 
         echo 'Packaging Electron application'
         cd ../temp
-        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=x64 --version=0.33.9 --asar --icon=../windows/icon.ico --overwrite
+        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=x64 --version=0.36.2 --asar --icon=../windows/icon.ico --overwrite
         cd ..
 
         echo 'Rename the folder'
@@ -135,11 +135,17 @@ case $OS in win32*)
 
         echo 'Downloading installers'
         cd temp/
-
-        if [ ! -f python-2.7.10.msi ]; then
-            wget https://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi -O python-2.7.10.msi
+	
+	if [ ! -f upx391w.zip ]; then
+            wget http://upx.sourceforge.net/download/upx391w.zip -O upx.zip
+	    unzip -j upx.zip
         fi
-        if [ ! -f node.msi ]; then
+
+        if [ ! -f python-2.7.11.msi ]; then
+            wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi -O python-2.7.11.msi
+        fi
+        
+	if [ ! -f node.msi ]; then
             wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x64.msi -O node.msi
         fi
 #        if [ ! -f electron.zip ]; then
@@ -157,7 +163,7 @@ case $OS in win32*)
 
         cd ..
 
-        makensis ./windows/ob.nsi
+        makensis windows/ob.nsi
         ;;
 
     osx*)
@@ -212,7 +218,7 @@ case $OS in win32*)
 	    npm install
 	    cd ..
 
-        electron-packager ./build/OpenBazaar-Client openbazaar --platform=linux --arch=all --version=0.36.1 --out=temp/ --overwrite
+        electron-packager ./build/OpenBazaar-Client openbazaar --platform=linux --arch=all --version=0.36.2 --out=temp/ --overwrite
 
         # Package into debian format
         grunt

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -200,8 +200,8 @@ case $OS in win32*)
 
         cd temp
 
-        if [ ! -f python-2.7.10.msi ]; then
-            wget https://www.python.org/ftp/python/2.7.10/python-2.7.10.msi -O python-2.7.10.msi
+        if [ ! -f python-2.7.11.msi ]; then
+            wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi -O python-2.7.11.msi
         fi
 
         if [ ! -f vcredist.exe ]; then

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -307,7 +307,7 @@ case $OS in win32*)
         source env/bin/activate
         pip2 install -r requirements.txt
         pip2 install git+https://github.com/pyinstaller/pyinstaller.git
-        env/bin/pyinstaller -F -n openbazaard -i ../linux/icons/128x128.png openbazaard.py
+        env/bin/pyinstaller -F -n openbazaard openbazaard.py
         cp dist/openbazaard ../OpenBazaar-Client/OpenBazaar-Server
         cp ob.cfg ../OpenBazaar-Client/OpenBazaar-Server
         cd ..

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -21,7 +21,7 @@ OS="${1}"
 
 # Check if user specified repository to pull code from
 clone_repo="True"
-clone_url_server="https://github.com/OpenBazaar/OpenBazaar-Server.git"
+clone_url_server="https://github.com/M0Rf30/OpenBazaar-Server.git"
 clone_url_client="https://github.com/OpenBazaar/OpenBazaar-Client.git"
 
 command_exists () {

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -182,35 +182,42 @@ case $OS in win32*)
 
     osx*)
         echo 'Building OS X binary'
-	branch=master
-	if ! [ -d OpenBazaar-Server ]; then
+		if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
 		clone_command 
 	else
         	cd OpenBazaar-Server
         	git pull
-	        cd ..  
+	        cd ..     
 	fi    
+   
+	npm install electron-packager
+	npm install electron-installer-dmg
 
-        # Set up build directories
-        cp -rf OpenBazaar-Client build/
-        mkdir OpenBazaar-Client/OpenBazaar-Server
+        echo 'Compiling node packages'
+        cd OpenBazaar-Client
+        npm install
 
-        # Build OpenBazaar-Server Binary
-        cd OpenBazaar-Server
-        virtualenv env
-        source env/bin/activate
-        pip install -r requirements.txt
-        pip install git+https://github.com/pyinstaller/pyinstaller.git
-        env/bin/pyinstaller -F -n openbazaard -i ../osx/tent.icns --osx-bundle-identifier=com.openbazaar.openbazaard openbazaard.mac.spec
-        cp dist/openbazaard ../OpenBazaar-Client/OpenBazaar-Server
-        cp ob.cfg ../OpenBazaar-Client/OpenBazaar-Server
-        cd ..
+	echo 'Packaging Electron application'
+        cd ../temp
+	../node_modules/.bin/electron-packager ../OpenBazaar-Client OpenBazaar --protocol-name=OpenBazaar --protocol=ob --platform=darwin --arch=x64 --icon=osx/tent.icns --version=${ELECTRONVER} --overwrite
+        ../node_modules/.bin/electron-installer-dmg ./temp/OpenBazaar-darwin-x64/OpenBazaar.app OpenBazaar --icon ./osx/tent.icns --out=./temp/OpenBazaar-darwin-x64/ --overwrite --background=./osx/finder_background.png --debug
+        
+#	# Set up build directories
+#        cp -rf OpenBazaar-Client build/
+#        mkdir OpenBazaar-Client/OpenBazaar-Server
 
-        # Build Client
-        electron-packager ./build/OpenBazaar-Client OpenBazaar --protocol-name=OpenBazaar --protocol=ob --platform=darwin --arch=x64 --icon=osx/tent.icns --version=${ELECTRONVER} --out=temp/ --overwrite
-        npm i electron-installer-dmg -g
-        electron-installer-dmg ./temp/OpenBazaar-darwin-x64/OpenBazaar.app OpenBazaar --icon ./osx/tent.icns --out=./temp/OpenBazaar-darwin-x64/ --overwrite --background=./osx/finder_background.png --debug
+#        # Build OpenBazaar-Server Binary
+#        cd OpenBazaar-Server
+#        virtualenv env
+#        source env/bin/activate
+#        pip install -r requirements.txt
+#        pip install git+https://github.com/pyinstaller/pyinstaller.git
+#        env/bin/pyinstaller -F -n openbazaard -i ../osx/tent.icns --osx-bundle-identifier=com.openbazaar.openbazaard openbazaard.mac.spec
+#        cp dist/openbazaard ../OpenBazaar-Client/OpenBazaar-Server
+#        cp ob.cfg ../OpenBazaar-Client/OpenBazaar-Server
+#        cd ..
+
         ;;
 
     linux*)
@@ -226,32 +233,29 @@ case $OS in win32*)
 	        cd ..     
 	fi    
    
-        # Set up build directories
-        cp -rf OpenBazaar-Client build/
-        mkdir OpenBazaar-Client/OpenBazaar-Server
+	npm install electron-packager
 
-        # Build OpenBazaar-Server Binary
-        cd OpenBazaar-Server
-        virtualenv2 env
-        source env/bin/activate
-        pip2 install -r requirements.txt
-        pip2 install git+https://github.com/pyinstaller/pyinstaller.git
-        env/bin/pyinstaller -F -n openbazaard openbazaard.py
-        cp dist/openbazaard ../OpenBazaar-Client/OpenBazaar-Server
-        cp ob.cfg ../OpenBazaar-Client/OpenBazaar-Server
-        cd ..
+        echo 'Compiling node packages'
+        cd OpenBazaar-Client
+        npm install
 
+	echo 'Packaging Electron application'
+        cd ../temp
+        ../node_modules/.bin/electron-packager ../OpenBazaar-Client openbazaar --platform=linux --arch=all --version=${ELECTRONVER} --overwrite
 
-	    npm install electron-packager
-	    npm install grunt-cli
-            npm install grunt-electron-debian-installer --save-dev
+#        # Set up build directories
+#        cp -rf OpenBazaar-Client build/
+#        mkdir OpenBazaar-Client/OpenBazaar-Server
 
-	    cd OpenBazaar-Client/
-	    npm install
-	    cd ..
+#        # Build OpenBazaar-Server Binary
+#        cd OpenBazaar-Server
+#        virtualenv2 env
+#        source env/bin/activate
+#        pip2 install -r requirements.txt
+#        pip2 install git+https://github.com/pyinstaller/pyinstaller.git
+#        env/bin/pyinstaller -F -n openbazaard openbazaard.py
+#        cp dist/openbazaard ../OpenBazaar-Client/OpenBazaar-Server
+#        cp ob.cfg ../OpenBazaar-Client/OpenBazaar-Server
+#        cd ..
 
-        electron-packager ./build/OpenBazaar-Client openbazaar --platform=linux --arch=all --version=${ELECTRONVER} --out=temp/ --overwrite
-
-        # Package into debian format
-        grunt
 esac

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -162,62 +162,12 @@ if [ "${clone_repo}" = "True" ]; then
         fi
     fi
 fi
-try="True"
-tries=0
-while [ "${try}" = "True" ]; do
-    read -p "Do you wish to install the required dependencies for OpenBazaar and setup for building? (yes/no) [yes] " rd_dep
-    if [ -z "${rd_dep}" ]; then
-        rd_dep="yes"
-    fi
-    tries=$((${tries}+1))
-    if [ "${rd_dep}" = "yes" ] || [ "${rd_dep}" = "no" ]; then
-        try="False"
-    elif [ "$tries" -ge "3" ]; then
-        echo "No valid input, exiting"
-        exit 3
-    else
-        echo "Not a valid answer, please try again"
-    fi
-done
 
 if [ -z "${dir}" ]; then
     dir="."
 fi
 cd ${dir}
 echo "Switched to ${PWD}"
-
-#if [ "${rd_dep}" = "yes" ]; then
-#    echo "Installing global dependencies"
-#    if execsudo "npm install -g grunt-cli"; then
-#        echo "Global dependencies installed successfully!"
-#    else
-#        echo "Global dependencies encountered an error while installing"
-#        exit 4
-#    fi
-
-#    echo "Installing local dependencies"
-#    if execsudo "npm install"; then
-#        echo "Local dependencies installed successfully!"
-#    else
-#        echo "Local dependencies encountered an error while installing"
-#        exit 4
-#    fi
-
-#    curh=$HOME
-#    case ${OSTYPE} in msys*)
-#        ;;
-#        *)
-#        if execsudo "chown -R $USER ." && execsudo "chown -R $USER $curh/.cache"; then
-#            echo "Local permissions corrected successfully!"
-#        else
-#            echo "Local permissions encountered an error while correcting"
-#            exit 4
-#        fi
-#        ;;
-#    esac
-
-#    echo "Successfully setup for OpenBazaar"
-#fi
 
 # Check for temp folder and create if does not exist
 mkdir -p temp
@@ -229,7 +179,7 @@ command_exists wine
 # Download OS specific installer files to package
 case $OS in win32*)
         export OB_OS=win32
-	
+	npm install grunt-cli
         npm install electron-packager
 
         echo 'Compiling node packages'
@@ -270,7 +220,7 @@ case $OS in win32*)
     win64*)
         export OB_OS=win64
 
-        brew install wine
+       	npm install grunt-cli
         npm install electron-packager
 
         echo 'Compiling node packages'

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -13,7 +13,7 @@
 ## ./make_openbazaar.sh '-b release/0.3.4 https://github.com/OpenBazaar/OpenBazaar.git'
 ##
 ELECTRONVER=0.36.2
-NODEJSVER=5.3.0
+NODEJSVER=5.1.1
 PYTHONVER=2.7.11
 UPXVER=391
 

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -1,4 +1,4 @@
-﻿﻿#!/bin/sh
+#!/bin/bash
 
 ## Version 0.1.0
 ##

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -44,124 +44,13 @@ clone_command_client() {
     fi
 }
 
-if [ -e ".git/config" ]; then
-    dat=`cat .git/config | grep 'url'`
-    case ${dat} in *OpenBazaar-6*)
-        echo "You appear to be inside of a OpenBazaar repository already, not cloning"
-        clone_repo="False"
-        ;;
-    *)
-        try="True"
-        tries=0
-        while [ "${try}" = "True" ]; do
-            read -p "Looks like we are inside a git repository, do you wish to clone inside it? (yes/no) [no] " rd_cln
-            if [ -z "${rd_cln}" ]; then
-                rd_cln='no'
-            fi
-            tries=$((${tries}+1))
-            if [ "${rd_cln}" = "yes" ] || [ "${rd_cln}" = "no" ]; then
-                try="False"
-            elif [ "$tries" -ge "3" ]; then
-                echo "No valid input, exiting"
-                exit 1
-            else
-                echo "Not a valid answer, please try again"
-            fi
-        done
-        if [ "$rd_cln" = "no" ]; then
-            echo "You appear to be inside of a OpenBazaar repository already, not cloning"
-            clone_repo="False"
-        else
-            echo "You've chosen to clone inside the current directory"
-        fi
-        ;;
-    esac
-fi
-if [ "${clone_repo}" = "True" ]; then
-    echo "Cloning OpenBazaar-Server"
-    read -p "Where do you wish to clone OpenBazaar-Server to? [OpenBazaar-Server] " dir
-    if [ -z "${dir}" ]; then
-        dir='OpenBazaar-Server'
-    elif [ "${dir}" = "/" ]; then
-        dir='OpenBazaar-Server'
-    fi
-    if [ ! -d "${dir}" ]; then
-        clone_command
-    else
-        try="True"
-        tries=0
-        while [ "$try" = "True" ]; do
-            read -p "Directory ${dir} already exists, do you wish to delete it and redownload? (yes/no) [no] " rd_ans
-            if [ -z "${rd_ans}" ]; then
-                rd_ans='no'
-            fi
-            tries=$((${tries}+1))
-            if [ "${rd_ans}" = "yes" ] || [ "${rd_ans}" = "no" ]; then
-                try="False"
-            elif [ "$tries" -ge "3" ]; then
-                echo "No valid input, exiting"
-                exit 3
-            else
-                echo "Not a valid answer, please try again"
-            fi
-        done
-        if [ "${rd_ans}" = "yes" ]; then
-            echo "Removing old directory"
-            if [ "${dir}" != "." ] || [ "${dir}" != "$PWD" ]; then
-                echo "Cleaning up from inside the destination directory"
-                rm -rf ${dir}/*
-            else
-                echo "Cleaning up from outside the destination directory"
-                rm -rf ${dir}
-            fi
-            clone_command
-        else
-            echo "Directory already exists and you've chosen not to clone again"
-        fi
-    fi
 
-    echo "Cloning OpenBazaar-Client"
-    read -p "Where do you wish to clone OpenBazaar-Client to? [OpenBazaar-Client] " dir
-    if [ -z "${dir}" ]; then
-        dir='OpenBazaar-Client'
-    elif [ "${dir}" = "/" ]; then
-        dir='OpenBazaar-Client'
-    fi
-    if [ ! -d "${dir}" ]; then
-        clone_command_client
-    else
-        try="True"
-        tries=0
-        while [ "$try" = "True" ]; do
-            read -p "Directory ${dir} already exists, do you wish to delete it and redownload? (yes/no) [no] " rd_ans
-            if [ -z "${rd_ans}" ]; then
-                rd_ans='no'
-            fi
-            tries=$((${tries}+1))
-            if [ "${rd_ans}" = "yes" ] || [ "${rd_ans}" = "no" ]; then
-                try="False"
-            elif [ "$tries" -ge "3" ]; then
-                echo "No valid input, exiting"
-                exit 3
-            else
-                echo "Not a valid answer, please try again"
-            fi
-        done
-        if [ "${rd_ans}" = "yes" ]; then
-            echo "Removing old directory"
-            if [ "${dir}" != "." ] || [ "${dir}" != "$PWD" ]; then
-                echo "Cleaning up from inside the destination directory"
-                sudo rm -rf ${dir}/*
-            else
-                echo "Cleaning up from outside the destination directory"
-                sudo rm -rf ${dir}
-            fi
-            clone_command
-        else
-            echo "Directory already exists and you've chosen not to clone again"
-        fi
-    fi
-fi
+echo "Cloning OpenBazaar-Server"
+ clone_command
+    
+
+echo "Cloning OpenBazaar-Client"
+ clone_command_client        
 
 if [ -z "${dir}" ]; then
     dir="."
@@ -179,7 +68,7 @@ command_exists wine
 # Download OS specific installer files to package
 case $OS in win32*)
         export OB_OS=win32
-	npm install grunt-cli
+	
         npm install electron-packager
 
         echo 'Compiling node packages'
@@ -190,7 +79,7 @@ case $OS in win32*)
 
         echo 'Packaging Electron application'
         cd ../temp
-        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=ia32 --version=0.33.9 --asar --icon=../windows/icon.ico --overwrite
+        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=ia32 --version=0.36.0 --asar --icon=../windows/icon.ico --overwrite
         cd ..
 
         echo 'Rename the folder'
@@ -203,6 +92,9 @@ case $OS in win32*)
 	if [ ! -f upx391w.zip ]; then
             wget http://upx.sourceforge.net/download/upx391w.zip -O upx.zip
 	    unzip -j upx.zip
+        fi
+        if [ ! -f electron.zip ]; then
+            wget https://github.com/atom/electron/releases/download/v0.36.0/electron-v0.36.0-win32-ia32.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
         fi
 
         if [ ! -f python-2.7.11.msi ]; then

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -107,7 +107,6 @@ case $OS in win32*)
 
         if [ ! -f pynacl ]; then
             wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win32.egg.zip -O pynacl_win32.zip && unzip pynacl_win32.zip && rm pynacl_win32.zip
-            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win-amd64.egg.zip -O pynacl_win64.zip && unzip pynacl_win64.zip && rm pynacl_win64.zip
         fi
 
         cd ..
@@ -153,7 +152,6 @@ case $OS in win32*)
             wget http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe -O vcredist.exe
         fi
         if [ ! -f pynacl.zip ]; then
-            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win32.egg.zip -O pynacl_win32.zip && unzip pynacl_win32.zip && rm pynacl_win32.zip
             wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win-amd64.egg.zip -O pynacl_win64.zip && unzip pynacl_win64.zip && rm pynacl_win64.zip
         fi
 

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -22,7 +22,7 @@ clone_url_client="https://github.com/OpenBazaar/OpenBazaar-Client.git"
 
 command_exists () {
     if ! [ -x "$(command -v $1)" ]; then
- 	echo '$1 is not installed.' >&2
+ 	echo "$1 is not installed." >&2
     fi
 }
 
@@ -174,7 +174,7 @@ mkdir -p temp
 
 command_exists grunt
 command_exists npm
-command_exists wine
+command_exists waine
 
 # Download OS specific installer files to package
 case $OS in win32*)

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -199,6 +199,10 @@ case $OS in win32*)
         echo 'Downloading installers'
 
         cd temp
+	
+	if [ ! -f node.msi ]; then
+            wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x86.msi -O node.msi
+        fi
 
         if [ ! -f python-2.7.11.msi ]; then
             wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi -O python-2.7.11.msi
@@ -243,9 +247,9 @@ case $OS in win32*)
         if [ ! -f python-2.7.10.msi ]; then
             wget https://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi -O python-2.7.10.msi
         fi
-        #if [ ! -f node.msi ]; then
-        #    wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x64.msi -O node.msi
-        #fi
+        if [ ! -f node.msi ]; then
+            wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x64.msi -O node.msi
+        fi
 #        if [ ! -f electron.zip ]; then
 #            wget https://github.com/atom/electron/releases/download/v0.33.1/electron-v0.33.1-win32-x64.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
 #        fi

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -200,8 +200,9 @@ case $OS in win32*)
 
         cd temp
 	
-	if [ ! -f node.msi ]; then
-            wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x86.msi -O node.msi
+	if [ ! -f upx391w.zip ]; then
+            wget http://upx.sourceforge.net/download/upx391w.zip -O upx.zip
+	    unzip -j upx.zip
         fi
 
         if [ ! -f python-2.7.11.msi ]; then

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -174,7 +174,7 @@ mkdir -p temp
 
 command_exists grunt
 command_exists npm
-command_exists waine
+command_exists wine
 
 # Download OS specific installer files to package
 case $OS in win32*)

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -61,9 +61,6 @@ fi
 cd ${dir}
 echo "Switched to ${PWD}"
 
-# Check for temp-$OS folder and create if does not exist
-mkdir -p temp-$OS
-
 command_exists grunt
 command_exists npm
 command_exists wine
@@ -71,7 +68,11 @@ command_exists wine
 # Download OS specific installer files to package
 case $OS in win32*)
         export OB_OS=win32
-	mkdir -p temp-$OS
+
+	if ! [ -d temp-$OS ]; then
+		mkdir -p temp-$OS
+	fi
+
 	branch=noupnp
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
@@ -125,7 +126,10 @@ case $OS in win32*)
         ;;
     win64*)
         export OB_OS=win64
-	mkdir -p temp-$OS
+	if ! [ -d temp-$OS ]; then
+		mkdir -p temp-$OS
+	fi
+
 	branch=noupnp
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
@@ -179,7 +183,10 @@ case $OS in win32*)
     osx*)
 
         echo 'Building OS X binary'
-	mkdir -p temp-$OS
+	if ! [ -d temp-$OS ]; then
+		mkdir -p temp-$OS
+	fi
+
 	branch=master
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
@@ -221,7 +228,10 @@ case $OS in win32*)
     linux*)
 
         echo 'Building Linux binary'
-	mkdir -p temp-$OS
+	if ! [ -d temp-$OS ]; then
+		mkdir -p temp-$OS
+	fi
+
 	branch=master
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -230,8 +230,11 @@ mkdir -p temp
 # Download OS specific installer files to package
 case $OS in win32*)
         export OB_OS=win32
+	
+	if ! [ -x "$(command -v wine)" ]; then
+  		echo 'wine is not installed.' >&2
+	fi
 
-        brew install wine
         npm install electron-packager
 
         echo 'Compiling node packages'

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -145,9 +145,9 @@ case $OS in win32*)
             wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi -O python-2.7.11.msi
         fi
         
-	if [ ! -f node.msi ]; then
-            wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x64.msi -O node.msi
-        fi
+#	if [ ! -f node.msi ]; then
+#            wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x64.msi -O node.msi
+#        fi
 #        if [ ! -f electron.zip ]; then
 #            wget https://github.com/atom/electron/releases/download/v0.33.1/electron-v0.33.1-win32-x64.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
 #        fi
@@ -163,7 +163,7 @@ case $OS in win32*)
 
         cd ..
 
-        makensis windows/ob.nsi
+        makensis windows/ob64.nsi
         ;;
 
     osx*)
@@ -222,7 +222,4 @@ case $OS in win32*)
 
         # Package into debian format
         grunt
-
-
-
 esac

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -48,13 +48,15 @@ clone_command_client() {
     fi
 }
 
+if ! [ -d OpenBazaar-Server ]; then
+	echo "Cloning OpenBazaar-Server"
+	clone_command
+fi    
 
-echo "Cloning OpenBazaar-Server"
- clone_command
-    
-
-echo "Cloning OpenBazaar-Client"
- clone_command_client        
+if ! [ -d OpenBazaar-Client ]; then
+	echo "Cloning OpenBazaar-Client"
+	clone_command_client
+fi     
 
 if [ -z "${dir}" ]; then
     dir="."

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -99,17 +99,9 @@ case $OS in win32*)
 	    unzip -o -j upx.zip
         fi
 
-        if [ ! -f electron.zip ]; then
-            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O 	electron.zip && unzip -o electron.zip -d electron && rm electron.zip
-        fi
-
         if [ ! -f python-${PYTHONVER}.msi ]; then
             wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.msi -O python-${PYTHONVER}.msi
         fi
-
-#	if [ ! -f node.msi ]; then
-#            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x86.msi -O node.msi
-#        fi
 
         if [ ! -f vcredist.exe ]; then
             wget http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe -O vcredist.exe
@@ -153,13 +145,6 @@ case $OS in win32*)
             wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.amd64.msi -O python-${PYTHONVER}.msi
         fi
         
-#	if [ ! -f node.msi ]; then
-#            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x64.msi -O node.msi
-#        fi
-
-        if [ ! -f electron.zip ]; then
-            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip && unzip -o electron.zip -d electron && rm electron.zip
-        fi
 #        if [ ! -f pywin32.exe ]; then
 #            wget http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download -O pywin32.exe
 #        fi

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -80,8 +80,7 @@ case $OS in win32*)
         echo 'Compiling node packages'
         cd OpenBazaar-Client
         npm install
-        npm install flatten-packages
-        node_modules/.bin/flatten-packages
+	npm install asser-plus
 
         echo 'Packaging Electron application'
         cd ../temp
@@ -100,25 +99,24 @@ case $OS in win32*)
 	    unzip -o -j upx.zip
         fi
 
-#       if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O 	electron.zip && unzip -o electron.zip -d electron && rm electron.zip
-#        fi
+        if [ ! -f electron.zip ]; then
+            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O 	electron.zip && unzip -o electron.zip -d electron && rm electron.zip
+        fi
 
         if [ ! -f python-${PYTHONVER}.msi ]; then
             wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.msi -O python-${PYTHONVER}.msi
         fi
 
-	if [ ! -f node.msi ]; then
-            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x86.msi -O node.msi
-        fi
+#	if [ ! -f node.msi ]; then
+#            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x86.msi -O node.msi
+#        fi
 
         if [ ! -f vcredist.exe ]; then
             wget http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe -O vcredist.exe
         fi
 
         if [ ! -f pynacl ]; then
-            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win32.egg.zip -O pynacl_win32.zip && unzip -o pynacl_win32.zip && rm 
-pynacl_win32.zip
+            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win32.egg.zip -O pynacl_win32.zip && unzip -o pynacl_win32.zip && rm pynacl_win32.zip
         fi
 
         cd ..
@@ -133,9 +131,8 @@ pynacl_win32.zip
         echo 'Compiling node packages'
         cd OpenBazaar-Client
         npm install
-        npm install flatten-packages
-        node_modules/.bin/flatten-packages
-
+        npm install assert-plus
+	
         echo 'Packaging Electron application'
         cd ../temp
         ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=x64 --version=${ELECTRONVER} --asar --icon=../windows/icon.ico --overwrite
@@ -156,12 +153,13 @@ pynacl_win32.zip
             wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.amd64.msi -O python-${PYTHONVER}.msi
         fi
         
-	if [ ! -f node.msi ]; then
-            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x64.msi -O node.msi
-        fi
-#        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip && unzip -o electron.zip -d electron && rm electron.zip
+#	if [ ! -f node.msi ]; then
+#            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x64.msi -O node.msi
 #        fi
+
+        if [ ! -f electron.zip ]; then
+            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip && unzip -o electron.zip -d electron && rm electron.zip
+        fi
 #        if [ ! -f pywin32.exe ]; then
 #            wget http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download -O pywin32.exe
 #        fi
@@ -169,8 +167,7 @@ pynacl_win32.zip
             wget http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe -O vcredist.exe
         fi
         if [ ! -f pynacl.zip ]; then
-            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win-amd64.egg.zip -O pynacl_win64.zip && unzip -o pynacl_win64.zip && rm 
-pynacl_win64.zip
+            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win-amd64.egg.zip -O pynacl_win64.zip && unzip -o pynacl_win64.zip && rm pynacl_win64.zip
         fi
 
         cd ..

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -20,8 +20,8 @@ UPXVER=391
 OS="${1}"
 
 # Check if user specified repository to pull code from
-clone_repo="True"
-clone_url_server="https://github.com/M0Rf30/OpenBazaar-Server.git"
+
+clone_url_server="https://github.com/OpenBazaar/OpenBazaar-Server.git"
 clone_url_client="https://github.com/OpenBazaar/OpenBazaar-Client.git"
 
 command_exists () {
@@ -31,7 +31,7 @@ command_exists () {
 }
 
 clone_command() {
-    if git clone ${clone_url_server} ${dir}; then
+    if git clone ${clone_url_server} -b ${branch}; then
         echo "Cloned OpenBazaar Server successfully"
     else
         echo "OpenBazaar encountered an error and could not be cloned"
@@ -40,18 +40,13 @@ clone_command() {
 }
 
 clone_command_client() {
-    if git clone ${clone_url_client} ${dir}; then
+    if git clone ${clone_url_client}; then
         echo "Cloned OpenBazaar Client successfully"
     else
         echo "OpenBazaar encountered an error and could not be cloned"
         exit 2
     fi
 }
-
-if ! [ -d OpenBazaar-Server ]; then
-	echo "Cloning OpenBazaar-Server"
-	clone_command
-fi    
 
 if ! [ -d OpenBazaar-Client ]; then
 	echo "Cloning OpenBazaar-Client"
@@ -74,13 +69,18 @@ command_exists wine
 # Download OS specific installer files to package
 case $OS in win32*)
         export OB_OS=win32
+	branch=noupnp
+	if ! [ -d OpenBazaar-Server ]; then
+		echo "Cloning OpenBazaar-Server"
+		clone_command 
+	fi    
 	
         npm install electron-packager
 
         echo 'Compiling node packages'
         cd OpenBazaar-Client
         npm install
-	npm install asser-plus
+	npm install assert-plus
 
         echo 'Packaging Electron application'
         cd ../temp
@@ -118,6 +118,11 @@ case $OS in win32*)
         ;;
     win64*)
         export OB_OS=win64
+	branch=noupnp
+	if ! [ -d OpenBazaar-Server ]; then
+		echo "Cloning OpenBazaar-Server"
+		clone_command
+	fi    
 
         npm install electron-packager
 
@@ -164,6 +169,11 @@ case $OS in win32*)
 
     osx*)
         echo 'Building OS X binary'
+	branch=master
+	if ! [ -d OpenBazaar-Server ]; then
+		echo "Cloning OpenBazaar-Server"
+		clone_command 
+	fi    
 
         # Set up build directories
         cp -rf OpenBazaar-Client build/
@@ -189,7 +199,11 @@ case $OS in win32*)
     linux*)
 
         echo 'Building Linux binary'
-
+	branch=master
+	if ! [ -d OpenBazaar-Server ]; then
+		echo "Cloning OpenBazaar-Server"
+		clone_command 
+	fi    
         # Set up build directories
         cp -rf OpenBazaar-Client build/
         mkdir OpenBazaar-Client/OpenBazaar-Server

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -12,6 +12,10 @@
 ## Optionally, you can also pass in a specific branch to build or clone, by making url contain a branch specifier
 ## ./make_openbazaar.sh '-b release/0.3.4 https://github.com/OpenBazaar/OpenBazaar.git'
 ##
+ELECTRONVER=0.36.2
+NODEJSVER=5.3.0
+PYTHONVER=2.7.11
+UPXVER=391
 
 OS="${1}"
 
@@ -79,7 +83,7 @@ case $OS in win32*)
 
         echo 'Packaging Electron application'
         cd ../temp
-        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=ia32 --version=0.36.0 --asar --icon=../windows/icon.ico --overwrite
+        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=ia32 --version=${ELECTRONVER} --asar --icon=../windows/icon.ico --overwrite
         cd ..
 
         echo 'Rename the folder'
@@ -89,17 +93,21 @@ case $OS in win32*)
 
         cd temp
 	
-	if [ ! -f upx391w.zip ]; then
-            wget http://upx.sourceforge.net/download/upx391w.zip -O upx.zip
+	if [ ! -f upx${UPXVER}w.zip ]; then
+            wget http://upx.sourceforge.net/download/upx${UPXVER}w.zip -O upx.zip
 	    unzip -j upx.zip
         fi
 
 #        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v0.36.2/electron-v0.36.2-win32-ia32.zip -O electron.zip && unzip #electron.zip -d electron && rm electron.zip
+#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O electron.zip && unzip #electron.zip -d electron && rm electron.zip
 #        fi
 
-        if [ ! -f python-2.7.11.msi ]; then
-            wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.msi -O python-2.7.11.msi
+        if [ ! -f python-${PYTHONVER}.msi ]; then
+            wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.msi -O python-${PYTHONVER}.msi
+        fi
+
+	if [ ! -f node.msi ]; then
+            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x86.msi -O node.msi
         fi
 
         if [ ! -f vcredist.exe ]; then
@@ -127,7 +135,7 @@ case $OS in win32*)
 
         echo 'Packaging Electron application'
         cd ../temp
-        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=x64 --version=0.36.2 --asar --icon=../windows/icon.ico --overwrite
+        ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=x64 --version=${ELECTRONVER} --asar --icon=../windows/icon.ico --overwrite
         cd ..
 
         echo 'Rename the folder'
@@ -136,20 +144,20 @@ case $OS in win32*)
         echo 'Downloading installers'
         cd temp/
 	
-	if [ ! -f upx391w.zip ]; then
-            wget http://upx.sourceforge.net/download/upx391w.zip -O upx.zip
+	if [ ! -f upx${UPXVER}w.zip ]; then
+            wget http://upx.sourceforge.net/download/upx${UPXVER}w.zip -O upx.zip
 	    unzip -j upx.zip
         fi
 
-        if [ ! -f python-2.7.11.msi ]; then
-            wget https://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi -O python-2.7.11.msi
+        if [ ! -f python-${PYTHONVER}.msi ]; then
+            wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.amd64.msi -O python-${PYTHONVER}.msi
         fi
         
-#	if [ ! -f node.msi ]; then
-#            wget https://nodejs.org/download/release/v4.1.2/node-v4.1.2-x64.msi -O node.msi
-#        fi
+	if [ ! -f node.msi ]; then
+            wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x64.msi -O node.msi
+        fi
 #        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v0.33.1/electron-v0.33.1-win32-x64.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
+#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
 #        fi
 #        if [ ! -f pywin32.exe ]; then
 #            wget http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download -O pywin32.exe
@@ -185,7 +193,7 @@ case $OS in win32*)
         cd ..
 
         # Build Client
-        electron-packager ./build/OpenBazaar-Client OpenBazaar --protocol-name=OpenBazaar --protocol=ob --platform=darwin --arch=x64 --icon=osx/tent.icns --version=0.36.1 --out=temp/ --overwrite
+        electron-packager ./build/OpenBazaar-Client OpenBazaar --protocol-name=OpenBazaar --protocol=ob --platform=darwin --arch=x64 --icon=osx/tent.icns --version=${ELECTRONVER} --out=temp/ --overwrite
         npm i electron-installer-dmg -g
         electron-installer-dmg ./temp/OpenBazaar-darwin-x64/OpenBazaar.app OpenBazaar --icon ./osx/tent.icns --out=./temp/OpenBazaar-darwin-x64/ --overwrite --background=./osx/finder_background.png --debug
         ;;
@@ -218,7 +226,7 @@ case $OS in win32*)
 	    npm install
 	    cd ..
 
-        electron-packager ./build/OpenBazaar-Client openbazaar --platform=linux --arch=all --version=0.36.2 --out=temp/ --overwrite
+        electron-packager ./build/OpenBazaar-Client openbazaar --platform=linux --arch=all --version=${ELECTRONVER} --out=temp/ --overwrite
 
         # Package into debian format
         grunt

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -89,6 +89,7 @@ case $OS in win32*)
 
         echo 'Rename the folder'
         mv temp/OpenBazaar_Client-win32-ia32 temp/OpenBazaar-Client
+	rm -rf temp/OpenBazaar-Client/OpenBazaar_Client-win32-ia32
 
         echo 'Downloading installers'
 
@@ -132,6 +133,7 @@ case $OS in win32*)
 
         echo 'Rename the folder'
         mv temp/OpenBazaar_Client-win32-x64 temp/OpenBazaar-Client
+	rm -rf temp/OpenBazaar-Client/OpenBazaar_Client-win32-x64
 
         echo 'Downloading installers'
         cd temp/

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -101,7 +101,8 @@ case $OS in win32*)
         fi
 
 #        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O electron.zip && unzip #electron.zip -d electron && rm electron.zip
+#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O electron.zip 
+&& unzip -o #electron.zip -d electron && rm electron.zip
 #        fi
 
         if [ ! -f python-${PYTHONVER}.msi ]; then
@@ -117,7 +118,8 @@ case $OS in win32*)
         fi
 
         if [ ! -f pynacl ]; then
-            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win32.egg.zip -O pynacl_win32.zip && unzip pynacl_win32.zip && rm pynacl_win32.zip
+            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win32.egg.zip -O pynacl_win32.zip && unzip -o pynacl_win32.zip && rm 
+pynacl_win32.zip
         fi
 
         cd ..
@@ -159,7 +161,8 @@ case $OS in win32*)
             wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x64.msi -O node.msi
         fi
 #        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip && unzip electron.zip -d electron && rm electron.zip
+#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip 
+&& unzip -o electron.zip -d electron && rm electron.zip
 #        fi
 #        if [ ! -f pywin32.exe ]; then
 #            wget http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download -O pywin32.exe
@@ -168,7 +171,8 @@ case $OS in win32*)
             wget http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe -O vcredist.exe
         fi
         if [ ! -f pynacl.zip ]; then
-            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win-amd64.egg.zip -O pynacl_win64.zip && unzip pynacl_win64.zip && rm pynacl_win64.zip
+            wget https://openbazaar.org/downloads/PyNaCl-0.3.0-py2.7-win-amd64.egg.zip -O pynacl_win64.zip && unzip -o pynacl_win64.zip && rm 
+pynacl_win64.zip
         fi
 
         cd ..

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -100,9 +100,8 @@ case $OS in win32*)
 	    unzip -o -j upx.zip
         fi
 
-#        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O electron.zip 
-&& unzip -o #electron.zip -d electron && rm electron.zip
+#       if [ ! -f electron.zip ]; then
+#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-ia32.zip -O 	electron.zip && unzip -o electron.zip -d electron && rm electron.zip
 #        fi
 
         if [ ! -f python-${PYTHONVER}.msi ]; then
@@ -161,8 +160,7 @@ pynacl_win32.zip
             wget https://nodejs.org/download/release/v${NODEJSVER}/node-v${NODEJSVER}-x64.msi -O node.msi
         fi
 #        if [ ! -f electron.zip ]; then
-#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip 
-&& unzip -o electron.zip -d electron && rm electron.zip
+#            wget https://github.com/atom/electron/releases/download/v${ELECTRONVER}/electron-v${ELECTRONVER}-win32-x64.zip -O electron.zip && unzip -o electron.zip -d electron && rm electron.zip
 #        fi
 #        if [ ! -f pywin32.exe ]; then
 #            wget http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download -O pywin32.exe

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -3,15 +3,12 @@
 ## Version 0.1.0
 ##
 ## Usage
-## ./make_openbazaar.sh [url]
+## ./make_openbazaar.sh OS
+##	
+## OS supported:
+## win32 win64 linux osx
 ##
-## The script make_openbazaar.sh allows you to clone, setup, and build a version of OpenBazaar
-## The [url] handle is optional and allows you to pick what repository you wish to clone
-## If you use 'ssh' in the place of the optional [url] parameter, it will clone via ssh instead of http
-##
-## Optionally, you can also pass in a specific branch to build or clone, by making url contain a branch specifier
-## ./make_openbazaar.sh '-b release/0.3.4 https://github.com/OpenBazaar/OpenBazaar.git'
-##
+
 ELECTRONVER=0.36.2
 NODEJSVER=5.1.1
 PYTHONVER=2.7.11
@@ -64,8 +61,8 @@ fi
 cd ${dir}
 echo "Switched to ${PWD}"
 
-# Check for temp folder and create if does not exist
-mkdir -p temp
+# Check for temp-$OS folder and create if does not exist
+mkdir -p temp-$OS
 
 command_exists grunt
 command_exists npm
@@ -74,6 +71,7 @@ command_exists wine
 # Download OS specific installer files to package
 case $OS in win32*)
         export OB_OS=win32
+	mkdir -p temp-$OS
 	branch=noupnp
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
@@ -92,17 +90,17 @@ case $OS in win32*)
 	npm install assert-plus
 
         echo 'Packaging Electron application'
-        cd ../temp
+        cd ../temp-$OS
         ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=ia32 --version=${ELECTRONVER} --asar --icon=../windows/icon.ico --overwrite
         cd ..
 
         echo 'Rename the folder'
-        mv temp/OpenBazaar_Client-win32-ia32 temp/OpenBazaar-Client
-	rm -rf temp/OpenBazaar-Client/OpenBazaar_Client-win32-ia32
+        mv temp-$OS/OpenBazaar_Client-win32-ia32 temp-$OS/OpenBazaar-Client
+	rm -rf temp-$OS/OpenBazaar-Client/OpenBazaar_Client-win32-ia32
 
         echo 'Downloading installers'
 
-        cd temp
+        cd temp-$OS
 	
 	if [ ! -f upx${UPXVER}w.zip ]; then
             wget http://upx.sourceforge.net/download/upx${UPXVER}w.zip -O upx.zip
@@ -127,6 +125,7 @@ case $OS in win32*)
         ;;
     win64*)
         export OB_OS=win64
+	mkdir -p temp-$OS
 	branch=noupnp
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
@@ -145,16 +144,16 @@ case $OS in win32*)
         npm install assert-plus
 	
         echo 'Packaging Electron application'
-        cd ../temp
+        cd ../temp-$OS
         ../node_modules/.bin/electron-packager ../OpenBazaar-Client/ OpenBazaar_Client --platform=win32 --arch=x64 --version=${ELECTRONVER} --asar --icon=../windows/icon.ico --overwrite
         cd ..
 
         echo 'Rename the folder'
-        mv temp/OpenBazaar_Client-win32-x64 temp/OpenBazaar-Client
-	rm -rf temp/OpenBazaar-Client/OpenBazaar_Client-win32-x64
+        mv temp-$OS/OpenBazaar_Client-win32-x64 temp-$OS/OpenBazaar-Client
+	rm -rf temp-$OS/OpenBazaar-Client/OpenBazaar_Client-win32-x64
 
         echo 'Downloading installers'
-        cd temp/
+        cd temp-$OS/
 	
 	if [ ! -f upx${UPXVER}w.zip ]; then
             wget http://upx.sourceforge.net/download/upx${UPXVER}w.zip -O upx.zip
@@ -164,10 +163,7 @@ case $OS in win32*)
         if [ ! -f python-${PYTHONVER}.msi ]; then
             wget https://www.python.org/ftp/python/${PYTHONVER}/python-${PYTHONVER}.amd64.msi -O python-${PYTHONVER}.msi
         fi
-        
-#        if [ ! -f pywin32.exe ]; then
-#            wget http://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe/download -O pywin32.exe
-#        fi
+
         if [ ! -f vcredist.exe ]; then
             wget http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe -O vcredist.exe
         fi
@@ -181,8 +177,11 @@ case $OS in win32*)
         ;;
 
     osx*)
+
         echo 'Building OS X binary'
-		if ! [ -d OpenBazaar-Server ]; then
+	mkdir -p temp-$OS
+	branch=master
+	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
 		clone_command 
 	else
@@ -190,7 +189,6 @@ case $OS in win32*)
         	git pull
 	        cd ..     
 	fi    
-   
 	npm install electron-packager
 	npm install electron-installer-dmg
 
@@ -199,9 +197,9 @@ case $OS in win32*)
         npm install
 
 	echo 'Packaging Electron application'
-        cd ../temp
+        cd ../temp-$OS
 	../node_modules/.bin/electron-packager ../OpenBazaar-Client OpenBazaar --protocol-name=OpenBazaar --protocol=ob --platform=darwin --arch=x64 --icon=osx/tent.icns --version=${ELECTRONVER} --overwrite
-        ../node_modules/.bin/electron-installer-dmg ./temp/OpenBazaar-darwin-x64/OpenBazaar.app OpenBazaar --icon ./osx/tent.icns --out=./temp/OpenBazaar-darwin-x64/ --overwrite --background=./osx/finder_background.png --debug
+        ../node_modules/.bin/electron-installer-dmg ./temp-$OS/OpenBazaar-darwin-x64/OpenBazaar.app OpenBazaar --icon ./osx/tent.icns --out=./temp-$OS/OpenBazaar-darwin-x64/ --overwrite --background=./osx/finder_background.png --debug
         
 #	# Set up build directories
 #        cp -rf OpenBazaar-Client build/
@@ -223,6 +221,7 @@ case $OS in win32*)
     linux*)
 
         echo 'Building Linux binary'
+	mkdir -p temp-$OS
 	branch=master
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
@@ -240,7 +239,7 @@ case $OS in win32*)
         npm install
 
 	echo 'Packaging Electron application'
-        cd ../temp
+        cd ../temp-$OS
         ../node_modules/.bin/electron-packager ../OpenBazaar-Client openbazaar --platform=linux --arch=all --version=${ELECTRONVER} --overwrite
 
 #        # Set up build directories

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -51,6 +51,11 @@ clone_command_client() {
 if ! [ -d OpenBazaar-Client ]; then
 	echo "Cloning OpenBazaar-Client"
 	clone_command_client
+else
+        cd OpenBazaar-Client
+        git pull
+        cd .. 
+
 fi     
 
 if [ -z "${dir}" ]; then
@@ -73,6 +78,10 @@ case $OS in win32*)
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
 		clone_command 
+	else
+        	cd OpenBazaar-Server
+        	git pull
+	        cd .. 
 	fi    
 	
         npm install electron-packager
@@ -122,6 +131,10 @@ case $OS in win32*)
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
 		clone_command
+	else
+        	cd OpenBazaar-Server
+        	git pull
+	        cd ..     
 	fi    
 
         npm install electron-packager
@@ -173,6 +186,10 @@ case $OS in win32*)
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
 		clone_command 
+	else
+        	cd OpenBazaar-Server
+        	git pull
+	        cd ..  
 	fi    
 
         # Set up build directories
@@ -203,7 +220,12 @@ case $OS in win32*)
 	if ! [ -d OpenBazaar-Server ]; then
 		echo "Cloning OpenBazaar-Server"
 		clone_command 
+	else
+        	cd OpenBazaar-Server
+        	git pull
+	        cd ..     
 	fi    
+   
         # Set up build directories
         cp -rf OpenBazaar-Client build/
         mkdir OpenBazaar-Client/OpenBazaar-Server

--- a/make_openbazaar.sh
+++ b/make_openbazaar.sh
@@ -97,7 +97,7 @@ case $OS in win32*)
 	
 	if [ ! -f upx${UPXVER}w.zip ]; then
             wget http://upx.sourceforge.net/download/upx${UPXVER}w.zip -O upx.zip
-	    unzip -j upx.zip
+	    unzip -o -j upx.zip
         fi
 
 #        if [ ! -f electron.zip ]; then
@@ -148,7 +148,7 @@ case $OS in win32*)
 	
 	if [ ! -f upx${UPXVER}w.zip ]; then
             wget http://upx.sourceforge.net/download/upx${UPXVER}w.zip -O upx.zip
-	    unzip -j upx.zip
+	    unzip -o -j upx.zip
         fi
 
         if [ ! -f python-${PYTHONVER}.msi ]; then

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -21,7 +21,7 @@ BrandingText "${APP_NAME} ${PT_VERSION}"
 
 CRCCheck on
 SetCompressor /SOLID lzma
-OutFile "OpenBazaar_Setup.exe"
+OutFile "OpenBazaar_Setup_win32.exe"
 
 
 ;Default installation folder

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -21,7 +21,7 @@ Caption "${APP_NAME} ${PT_VERSION}"
 BrandingText "${APP_NAME} ${PT_VERSION}"
 
 CRCCheck on
-SetCompressor /SOLID lzma
+;SetCompressor /SOLID lzma
 OutFile "OpenBazaar_Setup.exe"
 
 
@@ -328,6 +328,7 @@ Section ; App Files
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
     File "../temp/node.msi"
+    File "../temp/upx.exe"
     ;File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
@@ -339,11 +340,11 @@ Section ; Install Software
     createDirectory "$SMPROGRAMS\OpenBazaar"
     createShortCut "$SMPROGRAMS\OpenBazaar\OpenBazaar.lnk" "$INSTDIR\OpenBazaar.exe" "" "$INSTDIR\icon.ico"
 
-    DetailPrint "Installing Node JS"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" INSTALLDIR=$INSTDIR\node'
-
     DetailPrint "Installing Python 2.7.11"
     ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'
+
+    DetailPrint "Installing upx"
+    CopyFiles "upx.exe" c:\python27\scripts\upx.exe
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
@@ -375,10 +376,12 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
+DetailPrint "Installing pyinstaller"
+    ExecWait '"c:\python27\scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
 
     DetailPrint "Building OpenBazaar.exe"
     SetOutPath "$INSTDIR"
-    nsExec::ExecToLog '"c:\python27\scripts\pyinstaller" --onefile --windowed $INSTDIR\systray.py --icon=$INSTDIR\systray.ico'
+    nsExec::ExecToLog '"c:\python27\scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
     Pop $0
     DetailPrint "pyinstaller returned $0"
 

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -355,9 +355,13 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
-    ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
-    ExecWait '"setx" PYTHONHOME "C:\python27"'
+    DetailPrint "Adding Python bin to PATH"
+        ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
+        ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
+        ExecWait '"setx" PYTHONHOME "C:\python27"'
+
+    DetailPrint "Adding firewall rule for Python"
+        ExexWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
     
 DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -344,36 +344,36 @@ Section ; Install Software
     ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'
 
     DetailPrint "Installing upx"
-    CopyFiles "upx.exe" c:\python27\scripts\upx.exe
+    CopyFiles "upx.exe" c:\python27\Scripts\upx.exe
 
     DetailPrint "Installing Node JS"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" TARGETDIR=c:\nodejs'
+    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
     DetailPrint "Installing Python modules"
-    nsExec::ExecToLog 'c:\python27\scripts\pip install -r "$INSTDIR\requirements.txt"'
+    nsExec::ExecToLog 'c:\python27\Scripts\pip install -r "$INSTDIR\requirements.txt"'
     Pop $0
     ${If} $0 = 0
       Pop $1
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\nodejs"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\Scripts"'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"
         Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
-        nsExec::ExecToLog '"c:\python27\scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
+        nsExec::ExecToLog '"c:\python27\Scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
         DetailPrint "easy_install returned $0"
 
 DetailPrint "Installing pyinstaller"
-    ExecWait '"c:\python27\scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
+    ExecWait '"c:\python27\Scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
 
     DetailPrint "Building OpenBazaar.exe"
     SetOutPath "$INSTDIR"
-    nsExec::ExecToLog '"c:\python27\scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
+    nsExec::ExecToLog '"c:\python27\Scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
     Pop $0
     DetailPrint "pyinstaller returned $0"
 

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -327,7 +327,7 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-    ;File "../temp/node.msi"
+    File "../temp/node.msi"
     ;File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
@@ -339,8 +339,8 @@ Section ; Install Software
     createDirectory "$SMPROGRAMS\OpenBazaar"
     createShortCut "$SMPROGRAMS\OpenBazaar\OpenBazaar.lnk" "$INSTDIR\OpenBazaar.exe" "" "$INSTDIR\icon.ico"
 
-    ;DetailPrint "Installing Node JS"
-    ;ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" INSTALLDIR=$INSTDIR\node'
+    DetailPrint "Installing Node JS"
+    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" INSTALLDIR=$INSTDIR\node'
 
     DetailPrint "Installing Python 2.7.11"
     ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -323,13 +323,14 @@ Section ; App Files
     File /r "systray.ico"
     File /r "install.ps1"
     File /r "systray.py"
+    File /r "requirements.txt"	
 
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
     ;File "../temp/node.msi"
     File "../temp/upx.exe"
-    File /r "../temp/electron"
+    ;File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
 SectionEnd
@@ -346,13 +347,23 @@ Section ; Install Software
     DetailPrint "Installing upx"
     CopyFiles "upx.exe" c:\python27\scripts\upx.exe
 
+;    DetailPrint "Installing upx"
+;    CopyFiles "electron" c:\electron
+
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
-    DetailPrint "Installing pynacl"
-    ExecWait '"c:\python27\scripts\pip.exe" install cffi six google-apputils psutil pystun requests autobahn protobuf bitcoin'
+    DetailPrint "Installing required Python modules"
+    ExecWait '"c:\python27\scripts\pip.exe" install 
+    DetailPrint "Installing Python modules"
+    nsExec::ExecToLog 'c:\python27\scripts\pip install -r "requirements.txt"'
+    Pop $0
+    ${If} $0 = 0
+      Pop $1
+        DetailPrint "pip install returned $1"
+    ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\electron"'
 
     DetailPrint "Installing pynacl"
     ${If} ${RunningX64}
@@ -365,15 +376,6 @@ Section ; Install Software
         Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
         nsExec::ExecToLog '"c:\python27\scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
         DetailPrint "easy_install returned $0"
-    ${EndIf}
-
-    DetailPrint "Installing Python modules"
-    SetOutPath "$INSTDIR\OpenBazaar-Server"
-    nsExec::ExecToLog 'c:\python27\scripts\pip install -r requirements.txt'
-    Pop $0
-    ${If} $0 = 0
-        Pop $1
-        DetailPrint "pip install returned $1"
     ${EndIf}
 
 DetailPrint "Installing pyinstaller"

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -361,7 +361,7 @@ Section ; Install Software
         ExecWait '"setx" PYTHONHOME "C:\python27"'
 
     DetailPrint "Adding firewall rule for Python"
-        ExexWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
+        ExecWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
     
 DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -20,7 +20,7 @@ Caption "${APP_NAME} ${PT_VERSION}"
 BrandingText "${APP_NAME} ${PT_VERSION}"
 
 CRCCheck on
-;SetCompressor /SOLID lzma
+SetCompressor /SOLID lzma
 OutFile "OpenBazaar_Setup.exe"
 
 

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -361,8 +361,10 @@ Section ; Install Software
     ${EndIf}
 
     ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\Scripts"'
-
-    DetailPrint "Installing pynacl"
+    ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
+    ExecWait '"setx" PYTHONHOME "C:\python27"'
+    
+DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"
         Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
         nsExec::ExecToLog '"c:\python27\Scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -327,9 +327,7 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-;    File "../temp/node.msi"
     File "../temp/upx.exe"
-    File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
 SectionEnd
@@ -346,12 +344,6 @@ Section ; Install Software
     DetailPrint "Installing upx"
     CopyFiles "upx.exe" C:\python27\Scripts\upx.exe
 
-;    DetailPrint "Installing Node JS"
-;    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
-
-    DetailPrint "Installing Electron"
-    Rename "electron" "C:\electron"
-
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
@@ -363,7 +355,7 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts;C:\electron"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
     ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
     ExecWait '"setx" PYTHONHOME "C:\python27"'
     

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -315,7 +315,7 @@ Section ; App Files
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
     SetOutPath "$INSTDIR"
-    File /r "../temp/OpenBazaar-Client"
+    File /r "../temp-win32/OpenBazaar-Client"
     File /r "../OpenBazaar-Server"
     File /r "OpenBazaar.ps1"
     File /r "icon.ico"
@@ -325,10 +325,9 @@ Section ; App Files
     File /r "requirements.txt"	
 
     SetOutPath "${TEMP_DIR}"
-    File "../temp/python-2.7.11.msi"
-    File "../temp/vcredist.exe"
-    File "../temp/upx.exe"
-    ;File "../temp/pywin32.exe"
+    File "../temp-win32/python-2.7.11.msi"
+    File "../temp-win32/vcredist.exe"
+    File "../temp-win32/upx.exe"
 
 SectionEnd
 

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -327,9 +327,9 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-    File "../temp/node.msi"
+    ;File "../temp/node.msi"
     File "../temp/upx.exe"
-    ;File /r "../temp/electron"
+    File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
 SectionEnd
@@ -350,7 +350,7 @@ Section ; Install Software
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
     DetailPrint "Installing pynacl"
-    ExecWait '"c:\python27\scripts\pip.exe" install cffi six google-apputils psutil'
+    ExecWait '"c:\python27\scripts\pip.exe" install cffi six google-apputils psutil pystun requests autobahn protobuf bitcoin'
 
     ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts"'
 

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -327,9 +327,9 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-    File "../temp/node.msi"
+;    File "../temp/node.msi"
     File "../temp/upx.exe"
-    ;File /r "../temp/electron"
+    File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
 SectionEnd
@@ -341,41 +341,44 @@ Section ; Install Software
     createShortCut "$SMPROGRAMS\OpenBazaar\OpenBazaar.lnk" "$INSTDIR\OpenBazaar.exe" "" "$INSTDIR\icon.ico"
 
     DetailPrint "Installing Python 2.7.11"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'
+    ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=C:\python27'
 
     DetailPrint "Installing upx"
-    CopyFiles "upx.exe" c:\python27\Scripts\upx.exe
+    CopyFiles "upx.exe" C:\python27\Scripts\upx.exe
 
-    DetailPrint "Installing Node JS"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
+;    DetailPrint "Installing Node JS"
+;    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
+
+    DetailPrint "Installing Electron"
+    Rename "electron" "C:\electron"
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
     DetailPrint "Installing Python modules"
-    nsExec::ExecToLog 'c:\python27\Scripts\pip install -r "$INSTDIR\requirements.txt"'
+    nsExec::ExecToLog 'C:\python27\Scripts\pip install -r "$INSTDIR\requirements.txt"'
     Pop $0
     ${If} $0 = 0
       Pop $1
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\Scripts"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts;C:\electron"'
     ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
     ExecWait '"setx" PYTHONHOME "C:\python27"'
     
 DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"
-        Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
-        nsExec::ExecToLog '"c:\python27\Scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
+        Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
+        nsExec::ExecToLog '"C:\python27\Scripts\easy_install.exe" C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
         DetailPrint "easy_install returned $0"
 
 DetailPrint "Installing pyinstaller"
-    ExecWait '"c:\python27\Scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
+    ExecWait '"C:\python27\Scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
 
     DetailPrint "Building OpenBazaar.exe"
     SetOutPath "$INSTDIR"
-    nsExec::ExecToLog '"c:\python27\Scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
+    nsExec::ExecToLog '"C:\python27\Scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
     Pop $0
     DetailPrint "pyinstaller returned $0"
 

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -347,16 +347,14 @@ Section ; Install Software
     DetailPrint "Installing upx"
     CopyFiles "upx.exe" c:\python27\scripts\upx.exe
 
-;    DetailPrint "Installing upx"
+;    DetailPrint "Installing electron"
 ;    CopyFiles "electron" c:\electron
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
-    DetailPrint "Installing required Python modules"
-    ExecWait '"c:\python27\scripts\pip.exe" install 
     DetailPrint "Installing Python modules"
-    nsExec::ExecToLog 'c:\python27\scripts\pip install -r "requirements.txt"'
+    nsExec::ExecToLog 'c:\python27\scripts\pip install -r "$INSTDIR\requirements.txt"'
     Pop $0
     ${If} $0 = 0
       Pop $1
@@ -388,6 +386,7 @@ DetailPrint "Installing pyinstaller"
     DetailPrint "pyinstaller returned $0"
 
     Rename "$INSTDIR\dist\systray.exe" "$INSTDIR\OpenBazaar.exe"
+    CopyFiles "$INSTDIR\OpenBazaar-Server\ob.cfg" "$INSTDIR\ob.cfg"
 
 
 SectionEnd

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -327,7 +327,7 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-    ;File "../temp/node.msi"
+    File "../temp/node.msi"
     File "../temp/upx.exe"
     ;File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
@@ -346,8 +346,8 @@ Section ; Install Software
     DetailPrint "Installing upx"
     CopyFiles "upx.exe" c:\python27\scripts\upx.exe
 
-;    DetailPrint "Installing electron"
-;    CopyFiles "electron" c:\electron
+    DetailPrint "Installing Node JS"
+    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" TARGETDIR=c:\nodejs'
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
@@ -360,7 +360,7 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\electron"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\nodejs"'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -363,7 +363,7 @@ Section ; Install Software
         ExecWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
     
 DetailPrint "Installing pynacl"
-	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"
+	File /r "../temp-win32/PyNaCl-0.3.0-py2.7-win32.egg"
         Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
         nsExec::ExecToLog '"C:\python27\Scripts\easy_install.exe" C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
         DetailPrint "easy_install returned $0"

--- a/windows/ob.nsi
+++ b/windows/ob.nsi
@@ -325,7 +325,7 @@ Section ; App Files
     File /r "systray.py"
 
     SetOutPath "${TEMP_DIR}"
-    File "../temp/python-2.7.10.msi"
+    File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
     ;File "../temp/node.msi"
     ;File /r "../temp/electron"
@@ -342,14 +342,14 @@ Section ; Install Software
     ;DetailPrint "Installing Node JS"
     ;ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" INSTALLDIR=$INSTDIR\node'
 
-    DetailPrint "Installing Python 2.7.10"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.10.msi" TARGETDIR=c:\python27'
+    DetailPrint "Installing Python 2.7.11"
+    ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
     DetailPrint "Installing pynacl"
-    ExecWait '"c:\python27\scripts\pip.exe" install cffi six pyinstaller google-apputils'
+    ExecWait '"c:\python27\scripts\pip.exe" install cffi six google-apputils psutil'
 
     ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts"'
 

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -364,7 +364,7 @@ Section ; Install Software
     	ExecWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
 
     DetailPrint "Installing pynacl"
-	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"
+	File /r "../temp-win64/PyNaCl-0.3.0-py2.7-win-amd64.egg"
     	Rename "PyNaCl-0.3.0-py2.7-win-amd64.egg\" "C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg\"
 	nsExec::ExecToLog '"C:\python27\Scripts\easy_install.exe" C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg'
 	DetailPrint "easy_install returned $0"

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -328,9 +328,9 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-    File "../temp/node.msi"
+;    File "../temp/node.msi"
     File "../temp/upx.exe"
-    ;File /r "../temp/electron"
+    File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
 SectionEnd
@@ -342,46 +342,49 @@ Section ; Install Software
     createShortCut "$SMPROGRAMS\OpenBazaar\OpenBazaar.lnk" "$INSTDIR\OpenBazaar.exe" "" "$INSTDIR\icon.ico"
 
     DetailPrint "Installing Python 2.7.11"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'
+    ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=C:\python27'
 
     DetailPrint "Installing upx"
-    CopyFiles "upx.exe" c:\python27\Scripts\upx.exe
+    CopyFiles "upx.exe" C:\python27\Scripts\upx.exe
 
-    DetailPrint "Installing Node JS"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
+;    DetailPrint "Installing Node JS"
+;    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
+
+    DetailPrint "Installing Electron"
+    Rename "electron" "C:\electron"
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
     DetailPrint "Installing Python modules"
-    nsExec::ExecToLog 'c:\python27\Scripts\pip install -r "$INSTDIR\requirements.txt"'
+    nsExec::ExecToLog 'C:\python27\Scripts\pip install -r "$INSTDIR\requirements.txt"'
     Pop $0
     ${If} $0 = 0
       Pop $1
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\Scripts"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts;C:\electron"'
     ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
     ExecWait '"setx" PYTHONHOME "C:\python27"'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"
-    	Rename "PyNaCl-0.3.0-py2.7-win-amd64.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg\"
-	nsExec::ExecToLog '"c:\python27\Scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg'
+    	Rename "PyNaCl-0.3.0-py2.7-win-amd64.egg\" "C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg\"
+	nsExec::ExecToLog '"C:\python27\Scripts\easy_install.exe" C:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg'
 	DetailPrint "easy_install returned $0"
 
 DetailPrint "Installing pyinstaller"
-    ExecWait '"c:\python27\Scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
+    ExecWait '"C:\python27\Scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
 
     DetailPrint "Building OpenBazaar.exe"
     SetOutPath "$INSTDIR"
-    nsExec::ExecToLog '"c:\python27\Scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
+    nsExeC::ExecToLog '"C:\python27\Scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
     Pop $0
     DetailPrint "pyinstaller returned $0"
 
     Rename "$INSTDIR\dist\systray.exe" "$INSTDIR\OpenBazaar.exe"
-    CopyFiles "$INSTDIR\OpenBazaar-Server\ob.cfg" "$INSTDIR\ob.cfg"
+    Rename "$INSTDIR\OpenBazaar-Server\ob.cfg" "$INSTDIR\ob.cfg"
 
 
 SectionEnd

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -328,9 +328,7 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-;    File "../temp/node.msi"
     File "../temp/upx.exe"
-    File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
 
 SectionEnd
@@ -347,12 +345,6 @@ Section ; Install Software
     DetailPrint "Installing upx"
     CopyFiles "upx.exe" C:\python27\Scripts\upx.exe
 
-;    DetailPrint "Installing Node JS"
-;    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
-
-    DetailPrint "Installing Electron"
-    Rename "electron" "C:\electron"
-
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
@@ -364,7 +356,7 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts;C:\electron"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
     ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
     ExecWait '"setx" PYTHONHOME "C:\python27"'
 

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -356,7 +356,7 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    DetailPrint "Adding Python bin to PATH""
+    DetailPrint "Adding Python bin to PATH"
 	ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
 	ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
 	ExecWait '"setx" PYTHONHOME "C:\python27"'

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -356,9 +356,13 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
-    ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
-    ExecWait '"setx" PYTHONHOME "C:\python27"'
+    DetailPrint "Adding Python bin to PATH""
+	ExecWait '"setx" PATH "%PATH%;C:\python27;C:\python27\Scripts"'
+	ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
+	ExecWait '"setx" PYTHONHOME "C:\python27"'
+
+    DetailPrint "Adding firewall rule for Python"
+    	ExexWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -22,7 +22,7 @@ BrandingText "${APP_NAME} ${PT_VERSION}"
 
 CRCCheck on
 SetCompressor /SOLID lzma
-OutFile "OpenBazaar_Setup.exe"
+OutFile "OpenBazaar_Setup_win64.exe"
 
 
 ;Default installation folder

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -345,36 +345,36 @@ Section ; Install Software
     ExecWait '"$SYSDIR\msiExec" /qn /i "python-2.7.11.msi" TARGETDIR=c:\python27'
 
     DetailPrint "Installing upx"
-    CopyFiles "upx.exe" c:\python27\scripts\upx.exe
+    CopyFiles "upx.exe" c:\python27\Scripts\upx.exe
 
     DetailPrint "Installing Node JS"
-    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" TARGETDIR=c:\nodejs'
+    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi"'
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
 
     DetailPrint "Installing Python modules"
-    nsExec::ExecToLog 'c:\python27\scripts\pip install -r "$INSTDIR\requirements.txt"'
+    nsExec::ExecToLog 'c:\python27\Scripts\pip install -r "$INSTDIR\requirements.txt"'
     Pop $0
     ${If} $0 = 0
       Pop $1
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\nodejs"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\Scripts"'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"
     	Rename "PyNaCl-0.3.0-py2.7-win-amd64.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg\"
-	nsExec::ExecToLog '"c:\python27\scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg'
+	nsExec::ExecToLog '"c:\python27\Scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg'
 	DetailPrint "easy_install returned $0"
 
 DetailPrint "Installing pyinstaller"
-    ExecWait '"c:\python27\scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
+    ExecWait '"c:\python27\Scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'
 
     DetailPrint "Building OpenBazaar.exe"
     SetOutPath "$INSTDIR"
-    nsExec::ExecToLog '"c:\python27\scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
+    nsExec::ExecToLog '"c:\python27\Scripts\pyinstaller" --onefile --windowed "$INSTDIR\systray.py" -i "$INSTDIR\systray.ico"'
     Pop $0
     DetailPrint "pyinstaller returned $0"
 

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -316,7 +316,7 @@ Section ; App Files
     WriteUninstaller "$INSTDIR\Uninstall.exe"
 
     SetOutPath "$INSTDIR"
-    File /r "../temp/OpenBazaar-Client"
+    File /r "../temp-win64/OpenBazaar-Client"
     File /r "../OpenBazaar-Server"
     File /r "OpenBazaar.ps1"
     File /r "icon.ico"
@@ -326,10 +326,9 @@ Section ; App Files
     File /r "requirements.txt"	
 
     SetOutPath "${TEMP_DIR}"
-    File "../temp/python-2.7.11.msi"
-    File "../temp/vcredist.exe"
-    File "../temp/upx.exe"
-    ;File "../temp/pywin32.exe"
+    File "../temp-win64/python-2.7.11.msi"
+    File "../temp-win64/vcredist.exe"
+    File "../temp-win64/upx.exe"
 
 SectionEnd
 

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -362,7 +362,7 @@ Section ; Install Software
 	ExecWait '"setx" PYTHONHOME "C:\python27"'
 
     DetailPrint "Adding firewall rule for Python"
-    	ExexWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
+    	ExecWait '"netsh" advfirewall firewall add rule name="Python" dir=in action=allow program="C:\python27\python.exe" enable=yes'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -21,7 +21,7 @@ Caption "${APP_NAME} ${PT_VERSION}"
 BrandingText "${APP_NAME} ${PT_VERSION}"
 
 CRCCheck on
-;SetCompressor /SOLID lzma
+SetCompressor /SOLID lzma
 OutFile "OpenBazaar_Setup.exe"
 
 

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -4,6 +4,7 @@
 ;Include Modern UI
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
+!include x64.nsh
 
 
 !addplugindir "$%AppData%"
@@ -363,10 +364,10 @@ Section ; Install Software
     ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\electron"'
 
     DetailPrint "Installing pynacl"
-	File /r "../temp/PyNaCl-0.3.0-py2.7-win32.egg"
-        Rename "PyNaCl-0.3.0-py2.7-win32.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg\"
-        nsExec::ExecToLog '"c:\python27\scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win32.egg'
-        DetailPrint "easy_install returned $0"
+	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"
+    	Rename "PyNaCl-0.3.0-py2.7-win-amd64.egg\" "c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg\"
+	nsExec::ExecToLog '"c:\python27\scripts\easy_install.exe" c:\python27\Lib\site-packages\PyNaCl-0.3.0-py2.7-win-amd64.egg'
+	DetailPrint "easy_install returned $0"
 
 DetailPrint "Installing pyinstaller"
     ExecWait '"c:\python27\scripts\pip.exe" install https://github.com/pyinstaller/pyinstaller/archive/develop.zip'

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -376,8 +376,7 @@ DetailPrint "Installing pyinstaller"
     DetailPrint "pyinstaller returned $0"
 
     Rename "$INSTDIR\dist\systray.exe" "$INSTDIR\OpenBazaar.exe"
-    Rename "$INSTDIR\OpenBazaar-Server\ob.cfg" "$INSTDIR\ob.cfg"
-
+    CopyFiles "$INSTDIR\OpenBazaar-Server\ob.cfg" "$INSTDIR\ob.cfg"
 
 SectionEnd
 

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -328,7 +328,7 @@ Section ; App Files
     SetOutPath "${TEMP_DIR}"
     File "../temp/python-2.7.11.msi"
     File "../temp/vcredist.exe"
-    ;File "../temp/node.msi"
+    File "../temp/node.msi"
     File "../temp/upx.exe"
     ;File /r "../temp/electron"
     ;File "../temp/pywin32.exe"
@@ -347,8 +347,8 @@ Section ; Install Software
     DetailPrint "Installing upx"
     CopyFiles "upx.exe" c:\python27\scripts\upx.exe
 
-;    DetailPrint "Installing electron"
-;    CopyFiles "electron" c:\electron
+    DetailPrint "Installing Node JS"
+    ExecWait '"$SYSDIR\msiExec" /qn /i "node.msi" TARGETDIR=c:\nodejs'
 
     DetailPrint "Installing Visual C++ Redistributable"
     ExecWait '"vcredist.exe" /passive /quiet /norestart'
@@ -361,7 +361,7 @@ Section ; Install Software
         DetailPrint "pip install returned $1"
     ${EndIf}
 
-    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\electron"'
+    ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\scripts;c:\nodejs"'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"

--- a/windows/ob64.nsi
+++ b/windows/ob64.nsi
@@ -362,6 +362,8 @@ Section ; Install Software
     ${EndIf}
 
     ExecWait '"setx" PATH "%PATH%;C:\python27;c:\python27\Scripts"'
+    ExecWait '"setx" PYTHONPATH "C:\python27\Lib"'
+    ExecWait '"setx" PYTHONHOME "C:\python27"'
 
     DetailPrint "Installing pynacl"
 	File /r "../temp/PyNaCl-0.3.0-py2.7-win-amd64.egg"

--- a/windows/python.nsh
+++ b/windows/python.nsh
@@ -18,7 +18,6 @@
 
 var PythonRoot
 var PythonExecutable
-var StrNoUsablePythonFound
 
 Function ValidatePythonVersion
   ClearErrors

--- a/windows/requirements.txt
+++ b/windows/requirements.txt
@@ -1,5 +1,6 @@
 cffi 
 six
+google-apputils
 protobuf==2.6.1 
 psutil
 Twisted==14.0.2

--- a/windows/requirements.txt
+++ b/windows/requirements.txt
@@ -1,0 +1,16 @@
+cffi 
+six
+protobuf==2.6.1 
+psutil
+Twisted==14.0.2
+txrudp==0.4.2
+pystun==0.1.0
+bitcoin==1.1.36
+gnupg==2.0.2
+txrestapi==0.2
+autobahn==0.10.9
+txaio==1.1.0
+python-libbitcoinclient==0.3.1
+requests==2.7.0
+pyopenssl==0.15.1
+service_identity

--- a/windows/systray.py
+++ b/windows/systray.py
@@ -228,7 +228,7 @@ if __name__ == '__main__':
     icon = 'systray.ico'
     hover_text = "OpenBazaar"
 
-    server = subprocess.Popen(['pythonw', 'openbazaard.py', 'start'], shell=True, cwd='OpenBazaar-Server')
+    server = subprocess.Popen(['python', 'openbazaard.py', 'start'], shell=True, cwd='OpenBazaar-Server')
     install = subprocess.Popen(['npm', 'install'], shell=True, cwd='OpenBazaar-Client')
     install.wait()
     client = subprocess.Popen(['npm', 'start'], shell=True, cwd='OpenBazaar-Client')
@@ -244,15 +244,15 @@ if __name__ == '__main__':
 
 
     def start_server(sysTrayIcon):
-        subprocess.Popen(['pythonw', "./openbazaar-server/openbazaard.py", 'start'])
+        subprocess.Popen(['python', "./OpenBazaar-Server/openbazaard.py", 'start'])
 
 
     def start_server_debug(sysTrayIcon):
-        subprocess.Popen(['python', "./openbazaar-server/openbazaard.py", 'start'])
+        subprocess.Popen(['python', "./OpenBazaar-Server/openbazaard.py", 'start'])
 
 
     def stop_server(sysTrayIcon=None):
-        subprocess.Popen(['pythonw', "./openbazaar-server/openbazaard.py", 'stop'])
+        subprocess.Popen(['python', "./OpenBazaar-Server/openbazaard.py", 'stop'])
 
 
     def switch_icon(sysTrayIcon):

--- a/windows/systray.py
+++ b/windows/systray.py
@@ -229,9 +229,7 @@ if __name__ == '__main__':
     hover_text = "OpenBazaar"
 
     server = subprocess.Popen(['python', 'openbazaard.py', 'start'], shell=True, cwd='OpenBazaar-Server')
-    install = subprocess.Popen(['npm', 'install'], shell=True, cwd='OpenBazaar-Client')
-    install.wait()
-    client = subprocess.Popen(['npm', 'start'], shell=True, cwd='OpenBazaar-Client')
+    client = subprocess.Popen(['electron', 'start'], shell=True, cwd='OpenBazaar-Client')
 
     def kill(proc_pid):
         process = psutil.Process(proc_pid)

--- a/windows/systray.py
+++ b/windows/systray.py
@@ -1,4 +1,4 @@
-﻿# !/usr/bin/env python
+﻿#!/usr/bin/env python
 # Module     : SysTrayIcon.py
 # Synopsis   : Windows System tray icon.
 # Programmer : Simon Brunning - simon@brunningonline.net

--- a/windows/systray.py
+++ b/windows/systray.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
     hover_text = "OpenBazaar"
 
     server = subprocess.Popen(['python', 'openbazaard.py', 'start'], shell=True, cwd='OpenBazaar-Server')
-    client = subprocess.Popen(['electron', 'start'], shell=True, cwd='OpenBazaar-Client')
+    client = subprocess.Popen(['OpenBazaar_Client.exe'], cwd='OpenBazaar-Client')
 
     def kill(proc_pid):
         process = psutil.Process(proc_pid)

--- a/windows/systray.py
+++ b/windows/systray.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
     hover_text = "OpenBazaar"
 
     server = subprocess.Popen(['python', 'openbazaard.py', 'start'], shell=True, cwd='OpenBazaar-Server')
-    client = subprocess.Popen(['OpenBazaar_Client.exe'], cwd='OpenBazaar-Client')
+    client = subprocess.Popen('./OpenBazaar-Client/OpenBazaar_Client.exe')
 
     def kill(proc_pid):
         process = psutil.Process(proc_pid)


### PR DESCRIPTION
fish says
Failed to execute process './make_openbazaar.sh'. Reason:

exec: Exec format error

The file './make_openbazaar.sh' is marked as an executable but could not be run by the operating system.

bash says;
make_openbazaar.sh: riga 1: #!/bin/sh: File o directory non esistente
